### PR TITLE
Correct `uname` option

### DIFF
--- a/todo
+++ b/todo
@@ -63,7 +63,7 @@ function push_to_stack {
 }
 
 function find_when {
-    if [[ $(uname -o) == "Darwin" ]]; then
+    if [[ $(uname -s) == "Darwin" ]]; then
         WHEN="$(date -j -f %s "$1")"
     else
         WHEN="$(date --date "@$1")"


### PR DESCRIPTION
MacOS doesn't accept the `-o`(--operating-system) option; we'll use `-s` (--kernel-name)