### PR TITLE
Check for GNU date instead of Darwin OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ The workflow is basically this:
 In actual practice, it looks like:
 ```
 ╭─doug@nuc ~/repos/todo  ‹main*›
-╰─➤  ./todo push something2
-todo: Creating new todo: something2
+╰─➤  ./todo push "something I need to do"
+todo: Creating new todo: something I need to do
 todo: You have 1 todos
 <go handle the interruption>
 ╭─doug@nuc ~  ‹main*›
 ╰─➤  ~/repos/todo/todo pop
-todo: something2
+todo: something I need to do
 todo: cd /home/doug/repos/todo to continue this todo
 ╭─doug@nuc ~/repos/todo  ‹main*›
 ╰─➤  ~/repos/todo/todo pop

--- a/todo
+++ b/todo
@@ -33,6 +33,7 @@ DEFAULT_ACTION=help
 PRESERVE_QUEUE=false
 QUEUE_MODE=lifo
 PROJECTS_ONLY=false
+DATE_EXEC=/bin/date
 
 # functions
 function show_help {
@@ -64,15 +65,15 @@ function config_if_needed {
 function push_to_stack {
     _toplevel=$(git rev-parse --show-toplevel 2>/dev/null || echo "${PWD}")
     echo -e "${BLUE}todo: Creating new todo: ${NC}$@" && \
-    echo "~$(date +%s)~${_toplevel}~$@~" >> ${CONFIG_DIR}/todo.lst && \
+    echo "~$(${DATE_EXEC} +%s)~${_toplevel}~$@~" >> ${CONFIG_DIR}/todo.lst && \
     echo -e "${BLUE}todo: You have ${NC}$(wc -l ${CONFIG_DIR}/todo.lst | cut -d' ' -f1) ${BLUE}todos"
 }
 
 function find_when {
     if [[ $(uname -s) == "Darwin" ]]; then
-        WHEN="$(date -j -f %s "$1")"
+        WHEN="$(${DATE_EXEC} -j -f %s "$1")"
     else
-        WHEN="$(date --date "@$1")"
+        WHEN="$(${DATE_EXEC} --date "@$1")"
     fi
 }
 

--- a/todo
+++ b/todo
@@ -33,7 +33,6 @@ DEFAULT_ACTION=help
 PRESERVE_QUEUE=false
 QUEUE_MODE=lifo
 PROJECTS_ONLY=false
-DATE_EXEC=/bin/date
 
 # functions
 function show_help {
@@ -65,15 +64,15 @@ function config_if_needed {
 function push_to_stack {
     _toplevel=$(git rev-parse --show-toplevel 2>/dev/null || echo "${PWD}")
     echo -e "${BLUE}todo: Creating new todo: ${NC}$@" && \
-    echo "~$(${DATE_EXEC} +%s)~${_toplevel}~$@~" >> ${CONFIG_DIR}/todo.lst && \
+    echo "~$(date +%s)~${_toplevel}~$@~" >> ${CONFIG_DIR}/todo.lst && \
     echo -e "${BLUE}todo: You have ${NC}$(wc -l ${CONFIG_DIR}/todo.lst | cut -d' ' -f1) ${BLUE}todos"
 }
 
 function find_when {
-    if [[ $(uname -s) == "Darwin" ]]; then
-        WHEN="$(${DATE_EXEC} -j -f %s "$1")"
+    if date --version 2> /dev/null | grep -q GNU; then
+        WHEN="$(date --date "@$1")"
     else
-        WHEN="$(${DATE_EXEC} --date "@$1")"
+        WHEN="$(date -j -f %s "$1")"
     fi
 }
 


### PR DESCRIPTION
Checking for Darwin isn't great since many of us use GNU coreutils and that puts GNU `date` first in the `PATH`. This checks if the `date --version` returns `GNU` and handles the options based on that.

Also updated README to use multi-word example for philistines like myself.